### PR TITLE
Link to the models.rb file in the Examples

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,7 +2,7 @@ Here are some example usages of the gem, along with the generated SQL.
 
 Each of those methods can be chained with scoping methods, so they can be used on `Post`, `my_user.posts`, `Post.where('hello')` or inside a scope. Note that for the `*_sql` variants, those should preferably be used on classes only, because otherwise, it could be confusing for a reader.
 
-The models can be found in [examples/models.md](examples/models.md). The comments in that file explain how to get a console to try the queries. There are also example uses of the gem for scopes.
+The models can be found in [examples/models.rb](examples/models.rb). The comments in that file explain how to get a console to try the queries. There are also example uses of the gem for scopes.
 
 The content of this file is generated when running `rake`
 


### PR DESCRIPTION
In the readme the docs link to a file that does not exist. This links to the ruby file which I think may be the intended outcome.