### PR TITLE
Add support for Rails v7.2

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,6 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - gemfile: gemfiles/rails_7_2.gemfile
+            ruby_version: '3.3'
+
           - gemfile: gemfiles/rails_7_1.gemfile
             ruby_version: '3.2'
           - gemfile: gemfiles/rails_7_1.gemfile

--- a/.github/workflows/run_tests_on_head.yml
+++ b/.github/workflows/run_tests_on_head.yml
@@ -30,7 +30,7 @@ jobs:
           ruby_version: head
         - gemfile: gemfiles/rails_head.gemfile
           ruby_version: 3.2
-        - gemfile: gemfiles/rails_7_1.gemfile
+        - gemfile: gemfiles/rails_7_2.gemfile
           ruby_version: head
     runs-on: ubuntu-latest
     services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add compatibility for Rails 7.2
+
 # 1.1.4 - 2023-10-10
 
 * Add compatibility for Rails 7.1

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "activerecord", github: "rails/rails", branch: "7-2-stable"
+gem "sqlite3", "~> 1.4.0"
+gem "pg", "~> 1.1"
+gem "mysql2", "~> 0.5" if ENV["CI"] || ENV["ALL_DB"] || ENV["DB"] == "mysql"
+gem "prime"
+
+gemspec path: "../"

--- a/lib/active_record_where_assoc/active_record_compat.rb
+++ b/lib/active_record_where_assoc/active_record_compat.rb
@@ -72,7 +72,7 @@ module ActiveRecordWhereAssoc
       end
     end
 
-    if ActiveRecord.gem_version >= Gem::Version.new("4.2")
+    if ActiveRecord.gem_version >= Gem::Version.new("4.2") && ActiveRecord.gem_version < Gem::Version.new("7.2.0.alpha")
       def self.normalize_association_name(association_name)
         association_name.to_s
       end

--- a/test/support/base_test_model.rb
+++ b/test/support/base_test_model.rb
@@ -94,7 +94,7 @@ class BaseTestModel < ActiveRecord::Base
 
   def create_has_one!(association_name, attrs = {})
     association_name = ActiveRecordWhereAssoc::ActiveRecordCompat.normalize_association_name(association_name)
-    reflection = self.class.reflections[association_name]
+    reflection = self.class._reflections[association_name]
     raise "Didn't find association: #{association_name}" unless reflection
 
     target_model = reflection.klass
@@ -118,7 +118,7 @@ class BaseTestModel < ActiveRecord::Base
     association_name = ActiveRecordWhereAssoc::ActiveRecordCompat.normalize_association_name(association_name)
     association_macro = association_name.to_s[/^[a-z]+/]
 
-    reflection = self.class.reflections[association_name]
+    reflection = self.class._reflections[association_name]
     raise "Didn't find association: #{association_name}" unless reflection
 
     target_model = options[:target_model] || reflection.klass


### PR DESCRIPTION
Closes #14. Starting with a draft PR until an alpha release is officially cut. Also — I can't get the tests to pass locally, even for Rails v7.1, so I must not be doing something right or perhaps the contributing docs are out of date.

```bash
DB=sqlite3 BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile BUNDLE_PATH=.bundle bundle
DB=sqlite3 BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile BUNDLE_PATH=.bundle bundle exec rake test
# => .FFF..F........F.FFF..F........FFF..FF...FFFFFFFFFFFFFFF..FFF.F.FFFFF.FF.FFF.F.FFF..FFFF......FFF..FF...F..FFFF..FS.S.S.S....FFFFFFFFFFFFFFFFFFF.......FFF..FF...FFFFFFFFFFF.FFFFFF.FFF.FFFFFFFFF.FFFFFFFFFF.....FFF..FF...FFFFFFFF
#
#    Finished in 2.015876s, 112.6061 runs/s, 301.6058 assertions/s.
#
#      1) Failure:
#         wa#test_0002_finds a matching belongs_to [test/tests/scoping/wa_belongs_to_test.rb:26]:
#         Expected a match but got none for S0.where_assoc_count(matching_nb=1, :==, :b1, ...)
#         Doing the operations manually through ActiveRecord doesn't give the expected result. Expected to find a result with size == to 1, but got these sizes: [0].
#    ...
#    138) Failure:
#         wa#test_0006_polymorphic belongs_to on abstract model works on its descendant with poly_belongs_to: :pluck [test/tests/wa_abstract_model_test.rb:67]:
#         Expected a match but got none for S0.where_assoc_count(matching_nb=1, :==, :bp1, ...)
#         Doing the operations manually through ActiveRecord doesn't give the expected result. Expected to find a result with size == to 1, but got these sizes: [0].
#
#    227 runs, 608 assertions, 138 failures, 0 errors, 4 skips
```

Regardless, I think the failures are unrelated to the PR because they also fail locally on v7.1.