### PR TITLE
Fix operator in `where_assoc_count` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ my_post.comments.where_assoc_not_exists(:author, is_admin: true).where(...)
 Post.where_assoc_exists([:comments, :author], &:admins).where(...)
 
 # Find my_user's posts that have at least 5 non-spam comments (not_spam is a scope on comments)
-my_user.posts.where_assoc_count(5, :>=, :comments) { |comments| comments.not_spam }.where(...)
+my_user.posts.where_assoc_count(5, :<=, :comments) { |comments| comments.not_spam }.where(...)
 ```
 
 These allow for powerful, chainable, clear and easy to reuse queries. (Great for scopes)


### PR DESCRIPTION
Thank you for this awesome Gem!

Today, I needed a `where_assoc_count` and first got tricked by the order of arguments (but the Readme itself admits that it may be confusing at the start, so I'll live :D). But then I got tricked :again: by the example at the top of the Readme, because I think the operator is the wrong way around. (Or the comment explaining it is wrong.)

Further down in the Readme is this example, which is almost the same, but the operator is already correct:

```
# This has no equivalent (Posts with at least 5 spam comments)
Post.where_assoc_count(5, :<=, :comments, is_spam: true)
```